### PR TITLE
enhance custom periods for graphs

### DIFF
--- a/gui/components/common/CardGraphPeriodTools.svelte
+++ b/gui/components/common/CardGraphPeriodTools.svelte
@@ -2,6 +2,7 @@
   import { _ } from 'svelte-i18n';
   import { graphs } from '../../stores/terrariumpi';
   import { toggleGraphPeriod } from '../../helpers/graph-helpers';
+  import { tick } from 'svelte';
 
   export let id;
   export let replaced = false;
@@ -30,6 +31,8 @@
     event.stopPropagation();
     populateFromStore();
     showCustom = true;
+    await tick();
+    if (customStartInput) customStartInput.focus();
   }
 
   // Toggle include time and convert current values sensibly
@@ -74,41 +77,47 @@
   <div class="dropdown-menu dropdown-menu-right" role="menu" style="min-width: auto !important;">
     <button
       class="dropdown-item"
+      class:active="{$graphs[id].period === 'hour'}"
+      on:click="{() => toggleGraphPeriod(id, 'hour')}">{$_('graph.period.hour', { default: 'Hour' })}</button
+    >
+    <button
+      class="dropdown-item"
       class:active="{$graphs[id].period === 'day'}"
-      on:click="{() => toggleGraphPeriod(id, 'day')}"
+      on:click={() => toggleGraphPeriod(id, 'day')}
     >{$_('graph.period.day', { default: 'Day' })}</button>
 
     <button
       class="dropdown-item"
       class:active="{$graphs[id].period === 'week'}"
-      on:click="{() => toggleGraphPeriod(id, 'week')}"
+      on:click={() => toggleGraphPeriod(id, 'week')}
     >{$_('graph.period.week', { default: 'Week' })}</button>
 
     <button
       class="dropdown-item"
       class:active="{$graphs[id].period === 'month'}"
-      on:click="{() => toggleGraphPeriod(id, 'month')}"
+      on:click={() => toggleGraphPeriod(id, 'month')}
     >{$_('graph.period.month', { default: 'Month' })}</button>
 
     <button
       class="dropdown-item"
       class:active="{$graphs[id].period === 'year'}"
-      on:click="{() => toggleGraphPeriod(id, 'year')}"
+      on:click={() => toggleGraphPeriod(id, 'year')}
     >{$_('graph.period.year', { default: 'Year' })}</button>
 
     {#if replaced}
       <button
         class="dropdown-item"
         class:active="{$graphs[id].period === 'replaced'}"
-        on:click="{() => toggleGraphPeriod(id, 'replaced')}"
+        on:click={() => toggleGraphPeriod(id, 'replaced')}
       >{$_('graph.period.replaced', { default: 'Replaced' })}</button>
     {/if}
 
-    <!-- Custom period option: initialize and show date inputs -->
+    <!-- Custom period option: initialize and show date inputs.
+         Use stopPropagation on the click so Bootstrap does not auto-close the dropdown -->
     <button
       class="dropdown-item"
       class:active="{$graphs[id].period === 'custom'}"
-      on:click="{onCustomClick}"
+      on:click|stopPropagation={onCustomClick}
     >Custom</button>
 
     {#if showCustom}

--- a/gui/components/common/CardGraphPeriodTools.svelte
+++ b/gui/components/common/CardGraphPeriodTools.svelte
@@ -17,12 +17,6 @@
     const graph = $graphs[id];
     customStart = graph.customStart || '';
     customEnd = graph.customEnd || '';
-    includeTime = (customStart && customStart.includes('T')) || (customEnd && customEnd.includes('T'));
-  }
-
-  // Called when calendar icon is clicked (dropdown opens) — always show custom inputs prefilled
-  function onCalendarClick() {
-    populateFromStore();
     showCustom = true;
   }
 
@@ -75,11 +69,6 @@
   </button>
 
   <div class="dropdown-menu dropdown-menu-right" role="menu" style="min-width: auto !important;">
-    <button
-      class="dropdown-item"
-      class:active="{$graphs[id].period === 'hour'}"
-      on:click="{() => toggleGraphPeriod(id, 'hour')}">{$_('graph.period.hour', { default: 'Hour' })}</button
-    >
     <button
       class="dropdown-item"
       class:active="{$graphs[id].period === 'day'}"

--- a/terrariumAPI.py
+++ b/terrariumAPI.py
@@ -68,7 +68,6 @@ class terrariumAPI(object):
         bottle_app.route(
             "/api/areas/<area:path>/", "GET", self.area_detail, apply=self.authentication(False), name="api:area_detail"
         )
-
         bottle_app.route(
             "/api/areas/<area:path>/", "PUT", self.area_update, apply=self.authentication(), name="api:area_update"
         )
@@ -1429,12 +1428,22 @@ class terrariumAPI(object):
                 end_date_str = request.query.get('end_date')
                 if not start_date_str or not end_date_str:
                     return {"error": "start_date and end_date are required for custom period"}, 400
+
                 try:
-                    start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
-                    # Include the entire end date by adding one day minus one second
-                    end_date = datetime.strptime(end_date_str, "%Y-%m-%d") + timedelta(days=1) - timedelta(seconds=1)
-                except ValueError:
-                    return {"error": "Invalid date format. Use YYYY-MM-DD"}, 400
+                    # Accept either date-only (YYYY-MM-DD) or ISO datetime (YYYY-MM-DDTHH:MM[:SS])
+                    if "T" in start_date_str:
+                        start_date = datetime.fromisoformat(start_date_str)
+                    else:
+                        start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
+
+                    if "T" in end_date_str:
+                        end_date = datetime.fromisoformat(end_date_str)
+                    else:
+                        # Include the entire end date when a date-only is supplied
+                        end_date = datetime.strptime(end_date_str, "%Y-%m-%d") + timedelta(days=1) - timedelta(seconds=1)
+                except Exception:
+                    return {"error": "Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM"}, 400
+
                 use_custom = True
             else:
                 period = 1
@@ -1574,11 +1583,20 @@ class terrariumAPI(object):
             if not start_date_str or not end_date_str:
                 return {"error": "start_date and end_date are required for custom period"}, 400
             try:
-                start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
-                # Include the entire end date by adding one day minus one second
-                end_date = datetime.strptime(end_date_str, "%Y-%m-%d") + timedelta(days=1) - timedelta(seconds=1)
-            except ValueError:
-                return {"error": "Invalid date format. Use YYYY-MM-DD"}, 400
+                # Accept either date-only (YYYY-MM-DD) or ISO datetime (YYYY-MM-DDTHH:MM[:SS])
+                if "T" in start_date_str:
+                    start_date = datetime.fromisoformat(start_date_str)
+                else:
+                    start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
+
+                if "T" in end_date_str:
+                    end_date = datetime.fromisoformat(end_date_str)
+                else:
+                    # Include the entire end date when a date-only is supplied
+                    end_date = datetime.strptime(end_date_str, "%Y-%m-%d") + timedelta(days=1) - timedelta(seconds=1)
+            except Exception:
+                return {"error": "Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM"}, 400
+
             use_custom = True
         else:
             period = 1


### PR DESCRIPTION
This PR implements the following:
- `Custom` date range is visible immediately after the Calendar dropdown button is clicked and only disappears when both a start date and an end date is entered (vs the `Custom` date range only showing up after you click the Custom option followed by again clicking the Calendar button like before) 
- Adds timestamp to the `Custom `date range 

<img width="1904" height="600" alt="image" src="https://github.com/user-attachments/assets/cf90b8f0-7e83-495e-9217-32a7c8abaf00" />
