### PR TITLE
[BUG FIX] Display actual sensor measurements even when out of valid range

### DIFF
--- a/migrations/0005_add_sensor_out_of_range.sql
+++ b/migrations/0005_add_sensor_out_of_range.sql
@@ -1,0 +1,2 @@
+-- Add out_of_range column to SensorHistory to track measurements that are outside valid range
+ALTER TABLE "SensorHistory" ADD COLUMN "out_of_range" BOOLEAN NOT NULL DEFAULT 0;

--- a/terrariumDatabase.py
+++ b/terrariumDatabase.py
@@ -572,7 +572,13 @@ class Sensor(db.Entity):
             )
 
             sensor_data.exclude_avg = self.exclude_avg
-            sensor_data.out_of_range = out_of_range
+            if self.__VALUE_MODE == 2:
+                sensor_data.out_of_range = (
+                    sensor_data.value < sensor_data.limit_min
+                    or sensor_data.value > sensor_data.limit_max
+                )
+            else:
+                sensor_data.out_of_range = out_of_range
         else:
             # New data
             sensor_data = SensorHistory(

--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -715,6 +715,7 @@ class terrariumEngine(object):
                             "alarm_max",
                             "limit_min",
                             "limit_max",
+                            "alarm",
                             "unit",
                             "type",
                             "name",

--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -584,8 +584,23 @@ class terrariumEngine(object):
                     logger.warning(
                         f"{self.sensors[sensor.id]} had problems reading a new value during startup in {time.time()-start:.2f} seconds. Will be updated in the next round."
                     )
+                    continue
 
-                elif not sensor.limit_min <= value <= sensor.limit_max:
+                # Convert some values like temperature and distance ...
+                if "temperature" == sensor.type.lower():
+                    if "fahrenheit" == self.settings["temperature_indicator"]:
+                        value = terrariumUtils.to_fahrenheit(value)
+                    elif "kelvin" == self.settings["temperature_indicator"]:
+                        value = terrariumUtils.to_kelvin(value)
+
+                elif "distance" == sensor.type.lower():
+                    if "inch" == self.settings["distance_indicator"]:
+                        value = terrariumUtils.to_inches(value)
+
+                # We have a valid reading from the hardware sensor. Now increase/decrease with the offset
+                value += sensor.offset
+
+                if not sensor.limit_min <= value <= sensor.limit_max:
                     sensorLogger.warning(
                         f"Measurement for sensor {self.sensors[sensor.id]} of {value:.2f}{self.units[sensor.type]} is outside valid range {sensor.limit_min:.2f}{self.units[sensor.type]} to {sensor.limit_max:.2f}{self.units[sensor.type]} during startup in {time.time()-start:.2f} seconds. Recording as out-of-range measurement."
                     )
@@ -2044,8 +2059,7 @@ class terrariumEngine(object):
         else:
             # We are using total() vs sum() as total() will always return a number. https://sqlite.org/lang_aggfunc.html#sumunc
             with orm.db_session():
-                data = db.select(
-                    """SELECT
+                data = db.select("""SELECT
                         TOTAL(total_wattage) AS wattage,
                         TOTAL(total_flow)    AS flow,
                         IFNULL((JulianDay(MAX(off)) - JulianDay(MIN(`on`))) * 24 * 60 * 60,0) AS duration
@@ -2062,8 +2076,7 @@ class terrariumEngine(object):
                                 ON RH2.relay = RH1.relay
                                 AND RH2.timestamp = (SELECT MIN(timestamp) FROM RelayHistory WHERE timestamp > RH1.timestamp AND relay = RH1.relay)
                             WHERE RH1.value > 0
-                        )"""
-                )
+                        )""")
 
                 totals = {"total_watt": data[0][0], "total_flow": data[0][1], "duration": data[0][2]}
                 thread_return[0] = totals


### PR DESCRIPTION
- Add 'out_of_range' boolean column to SensorHistory table via migration
- Modify Sensor.error property to check for out-of-range measurements
- Update Sensor.update() method to accept and store out_of_range flag
- Change engine logic to store out-of-range measurements instead of skipping them
- This allows users to see actual measured values while still being notified of errors
- Applies to both startup and ongoing sensor measurements

Previously, measurements outside valid range (e.g., 162.84cm for a 0-50cm sensor) would be silently skipped, showing 'error' with no value - very misleading to users. Now the actual measurement is stored and displayed with an error indicator.