### PR TITLE
[BUG FIX] Fix CORS for Nocturnal Eye HLS stream

### DIFF
--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -275,6 +275,14 @@ class terrariumWebserver(object):
     def _get_nocturnal_eye_stream(self):
         """Return the HLS stream manifest for nocturnal-eye gecko monitoring without authentication"""
         import glob
+
+        # CORS headers for cross-origin access
+        cors_headers = {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+            "Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
+        }
+
         
         # Handle OPTIONS preflight request for CORS
         if request.method == "OPTIONS":
@@ -286,72 +294,63 @@ class terrariumWebserver(object):
         # Find the latest webcam stream directory
         webcam_dir = Path("/dev/shm/webcam")
         if not webcam_dir.exists():
-            return HTTPError(404, "Webcam stream not available")
-        
+            return HTTPError(404, "Webcam stream not available", **cors_headers)
+
         # Get the first (usually only) subdirectory
         stream_dirs = list(webcam_dir.glob("*/stream.m3u8"))
         if not stream_dirs:
-            return HTTPError(404, "No active stream found")
-        
+            return HTTPError(404, "No active stream found", **cors_headers)
+
         stream_file = stream_dirs[0]
-        
+
         # Read and return the m3u8 file
         try:
             response.content_type = "application/vnd.apple.mpegurl"
             response.set_header("Cache-Control", "no-cache, no-store, must-revalidate")
             response.set_header("Pragma", "no-cache")
             response.set_header("Expires", "0")
-            response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
-            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
-            
-            with open(stream_file, 'r') as f:
+            # Set CORS headers on response object for successful response
+            for header, value in cors_headers.items():
+                response.set_header(header, value)
+
+            with open(stream_file, "r") as f:
                 content = f.read()
-            
+
             # Convert relative paths to absolute URLs with proper host:port for HLS protocol compliance
             # Use configured host and port instead of untrusted Host header to prevent injection attacks
             configured_host = f"{self.engine.settings['host']}:{self.engine.settings['port']}"
-            content = re.sub(r'^(chunk_\d+\.ts)$', f'http://{configured_host}/nocturnal-eye/chunks/\\1', content, flags=re.MULTILINE)
-            
+            content = re.sub(
+                r"^(chunk_\d+\.ts)$", f"http://{configured_host}/nocturnal-eye/chunks/\\1", content, flags=re.MULTILINE
+            )
+
             return content
         except Exception as e:
             logger.error(f"Error reading stream: {e}")
-            return HTTPError(500, "Error reading stream")
+            return HTTPError(500, "Error reading stream", **cors_headers)
 
     def _get_nocturnal_eye_chunk(self, filename):
         """Serve HLS stream chunks for nocturnal-eye"""
         from pathlib import Path
         import re
-        
-        # Set CORS headers for all responses (including errors)
-        response.set_header("Access-Control-Allow-Origin", "*")
-        response.set_header("Access-Control-Allow-Methods", "GET, HEAD")
-        response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
-        # Handle OPTIONS preflight request for CORS
-        if request.method == "OPTIONS":
-            response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
-            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
-            return ""
-        
+
         # Validate filename to prevent path traversal attacks
         # Only allow alphanumeric characters, dots, underscores, and hyphens
         # This prevents path separators (/, \) and traversal sequences (..)
-        if not re.match(r'^[a-zA-Z0-9._-]+$', filename):
+        if not re.match(r"^[a-zA-Z0-9._-]+$", filename):
             return HTTPError(400, "Invalid filename")
-        
+
         # Find the webcam stream directory
         webcam_dir = Path("/dev/shm/webcam")
         if not webcam_dir.exists():
             return HTTPError(404, "Webcam stream not available")
-        
+
         # Get the first subdirectory
         stream_dirs = list(webcam_dir.glob("*/"))
         if not stream_dirs:
             return HTTPError(404, "No active stream found")
-        
+
         chunk_file = stream_dirs[0] / filename
-        
+
         # Resolve the path and verify it's still within the stream directory
         try:
             resolved_chunk = chunk_file.resolve()
@@ -360,19 +359,22 @@ class terrariumWebserver(object):
                 return HTTPError(403, "Access denied")
         except Exception:
             return HTTPError(400, "Invalid file path")
-        
+
         # Verify the file exists and is a valid chunk
-        if not resolved_chunk.exists() or not (filename.endswith('.ts') or filename.endswith('.jpg')):
+        if not resolved_chunk.exists() or not (filename.endswith(".ts") or filename.endswith(".jpg")):
             return HTTPError(404, "Chunk not found")
-        
+
         try:
             response.set_header("Cache-Control", "public, max-age=10")
-            if filename.endswith('.ts'):
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD")
+            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
+            if filename.endswith(".ts"):
                 response.content_type = "video/mp2t"
-            elif filename.endswith('.jpg'):
+            elif filename.endswith(".jpg"):
                 response.content_type = "image/jpeg"
-            
-            with open(resolved_chunk, 'rb') as f:
+
+            with open(resolved_chunk, "rb") as f:
                 return f.read()
         except Exception as e:
             logger.error(f"Error serving chunk: {e}")
@@ -476,7 +478,7 @@ class terrariumWebserver(object):
             method=["GET", "OPTIONS"],
             callback=self._get_nocturnal_eye_stream,
         )
-        
+
         # Nocturnal Eye stream chunks
         self.bottle.route(
             "/nocturnal-eye/chunks/<filename:path>",

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -333,6 +333,13 @@ class terrariumWebserver(object):
         from pathlib import Path
         import re
 
+        # Handle CORS preflight requests
+        if request.method == "OPTIONS":
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
+            response.status = 204
+            return ""
         # Validate filename to prevent path traversal attacks
         # Only allow alphanumeric characters, dots, underscores, and hyphens
         # This prevents path separators (/, \) and traversal sequences (..)

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -350,7 +350,7 @@ class terrariumWebserver(object):
         try:
             response.set_header("Cache-Control", "public, max-age=10")
             response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD")
             response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
             if filename.endswith('.ts'):
                 response.content_type = "video/mp2t"

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -276,6 +276,13 @@ class terrariumWebserver(object):
         """Return the HLS stream manifest for nocturnal-eye gecko monitoring without authentication"""
         import glob
         
+        # Handle OPTIONS preflight request for CORS
+        if request.method == "OPTIONS":
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
+            return ""
+        
         # Find the latest webcam stream directory
         webcam_dir = Path("/dev/shm/webcam")
         if not webcam_dir.exists():
@@ -316,6 +323,13 @@ class terrariumWebserver(object):
         from pathlib import Path
         import re
         
+        # Handle OPTIONS preflight request for CORS
+        if request.method == "OPTIONS":
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
+            return ""
+        
         # Validate filename to prevent path traversal attacks
         # Only allow alphanumeric characters, dots, underscores, and hyphens
         # This prevents path separators (/, \) and traversal sequences (..)
@@ -350,7 +364,7 @@ class terrariumWebserver(object):
         try:
             response.set_header("Cache-Control", "public, max-age=10")
             response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Methods", "GET, HEAD")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
             response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
             if filename.endswith('.ts'):
                 response.content_type = "video/mp2t"
@@ -458,14 +472,14 @@ class terrariumWebserver(object):
         # Nocturnal Eye stream bypass - unauthenticated access to live stream for gecko monitoring
         self.bottle.route(
             "/nocturnal-eye/stream.m3u8",
-            method="GET",
+            method=["GET", "OPTIONS"],
             callback=self._get_nocturnal_eye_stream,
         )
         
         # Nocturnal Eye stream chunks
         self.bottle.route(
             "/nocturnal-eye/chunks/<filename:path>",
-            method="GET",
+            method=["GET", "OPTIONS"],
             callback=self._get_nocturnal_eye_chunk,
         )
 

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -323,6 +323,10 @@ class terrariumWebserver(object):
         from pathlib import Path
         import re
         
+        # Set CORS headers for all responses (including errors)
+        response.set_header("Access-Control-Allow-Origin", "*")
+        response.set_header("Access-Control-Allow-Methods", "GET, HEAD")
+        response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
         # Handle OPTIONS preflight request for CORS
         if request.method == "OPTIONS":
             response.set_header("Access-Control-Allow-Origin", "*")
@@ -363,9 +367,6 @@ class terrariumWebserver(object):
         
         try:
             response.set_header("Cache-Control", "public, max-age=10")
-            response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
-            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
             if filename.endswith('.ts'):
                 response.content_type = "video/mp2t"
             elif filename.endswith('.jpg'):

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -294,6 +294,9 @@ class terrariumWebserver(object):
             response.set_header("Cache-Control", "no-cache, no-store, must-revalidate")
             response.set_header("Pragma", "no-cache")
             response.set_header("Expires", "0")
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
             
             with open(stream_file, 'r') as f:
                 content = f.read()
@@ -346,6 +349,9 @@ class terrariumWebserver(object):
         
         try:
             response.set_header("Cache-Control", "public, max-age=10")
+            response.set_header("Access-Control-Allow-Origin", "*")
+            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
+            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
             if filename.endswith('.ts'):
                 response.content_type = "video/mp2t"
             elif filename.endswith('.jpg'):

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -305,12 +305,16 @@ class terrariumWebserver(object):
         # Find the latest webcam stream directory
         webcam_dir = Path("/dev/shm/webcam")
         if not webcam_dir.exists():
-            return HTTPError(404, "Webcam stream not available", **cors_headers)
+            for header, value in cors_headers.items():
+                response.set_header(header, value)
+            return HTTPError(404, "Webcam stream not available")
 
         # Get the first (usually only) subdirectory
         stream_dirs = list(webcam_dir.glob("*/stream.m3u8"))
         if not stream_dirs:
-            return HTTPError(404, "No active stream found", **cors_headers)
+            for header, value in cors_headers.items():
+                response.set_header(header, value)
+            return HTTPError(404, "No active stream found")
 
         stream_file = stream_dirs[0]
 
@@ -337,7 +341,9 @@ class terrariumWebserver(object):
             return content
         except Exception as e:
             logger.error(f"Error reading stream: {e}")
-            return HTTPError(500, "Error reading stream", **cors_headers)
+            for header, value in cors_headers.items():
+                response.set_header(header, value)
+            return HTTPError(500, "Error reading stream")
 
     def _get_nocturnal_eye_chunk(self, filename):
         """Serve HLS stream chunks for nocturnal-eye"""

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -275,21 +275,33 @@ class terrariumWebserver(object):
     def _get_nocturnal_eye_stream(self):
         """Return the HLS stream manifest for nocturnal-eye gecko monitoring without authentication"""
         import glob
+        # Determine allowed CORS origin based on configuration and request
+        request_origin = request.headers.get("Origin")
+        allowed_origins = self.engine.settings.get("nocturnal_eye_allowed_origins", [])
+        cors_origin = None
+        if request_origin and isinstance(allowed_origins, (list, tuple, set)):
+            if request_origin in allowed_origins:
+                cors_origin = request_origin
+        elif request_origin and allowed_origins == "*":
+            # If explicitly configured as "*", allow any origin (opt-in)
+            cors_origin = request_origin
 
-        # CORS headers for cross-origin access
+        # CORS headers for cross-origin access (only if origin is allowed)
         cors_headers = {
-            "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
             "Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
         }
+        if cors_origin:
+            cors_headers["Access-Control-Allow-Origin"] = cors_origin
 
         # Handle OPTIONS preflight request for CORS
         if request.method == "OPTIONS":
-            response.set_header("Access-Control-Allow-Origin", "*")
-            response.set_header("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
-            response.set_header("Access-Control-Allow-Headers", "Origin, Accept, Content-Type, X-Requested-With")
+            if not cors_origin:
+                # Origin not allowed or not configured for CORS access
+                return HTTPError(403, "CORS origin not allowed")
+            for header, value in cors_headers.items():
+                response.set_header(header, value)
             return ""
-        
         # Find the latest webcam stream directory
         webcam_dir = Path("/dev/shm/webcam")
         if not webcam_dir.exists():

--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -283,7 +283,6 @@ class terrariumWebserver(object):
             "Access-Control-Allow-Headers": "Origin, Accept, Content-Type, X-Requested-With",
         }
 
-        
         # Handle OPTIONS preflight request for CORS
         if request.method == "OPTIONS":
             response.set_header("Access-Control-Allow-Origin", "*")


### PR DESCRIPTION
### Summary

- Add CORS headers to Nocturnal Eye HLS manifest and chunk responses to allow cross-origin playback.
- Prevent CORS-related stream load failures in the web UI.