### PR TITLE
[BUG FIX] Fix monitoring page layout and recent snapshots loading

### DIFF
--- a/gui/pages/Monitoring.svelte
+++ b/gui/pages/Monitoring.svelte
@@ -779,67 +779,6 @@
         </div>
       </div>
     </div>
-
-    {#if selectedSnapshot}
-      <div class="snapshot-modal-overlay" on:click="{closeSnapshotModal}">
-        <div
-          bind:this="{modalContentEl}"
-          class="snapshot-modal-content"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Fullscreen snapshot viewer"
-          on:click|stopPropagation
-        >
-          <button
-            bind:this="{closeButtonEl}"
-            class="snapshot-modal-close"
-            on:click="{closeSnapshotModal}"
-            title="Close (ESC)"
-            aria-label="Close snapshot viewer"
-          >
-            <i class="fas fa-times" aria-hidden="true"></i>
-          </button>
-
-          {#if modalSnapshots.length > 1 && selectedSnapshotIndex > 0}
-            <button
-              class="snapshot-modal-nav prev"
-              on:click="{showPreviousSnapshot}"
-              title="Previous (←)"
-              aria-label="Previous snapshot"
-            >
-              <i class="fas fa-chevron-left" aria-hidden="true"></i>
-            </button>
-          {/if}
-
-          <img src="{selectedSnapshot.path}" alt="Fullscreen snapshot" class="snapshot-modal-image" />
-
-          {#if modalSnapshots.length > 1 && selectedSnapshotIndex < modalSnapshots.length - 1}
-            <button
-              class="snapshot-modal-nav next"
-              on:click="{showNextSnapshot}"
-              title="Next (→)"
-              aria-label="Next snapshot"
-            >
-              <i class="fas fa-chevron-right" aria-hidden="true"></i>
-            </button>
-          {/if}
-
-          <div class="snapshot-modal-info">
-            <div><strong>Detected:</strong> {formatDate(selectedSnapshot.timestamp)}</div>
-            {#if selectedSnapshot.metadata?.detection_count != null}
-              <div><strong>Detections:</strong> {selectedSnapshot.metadata.detection_count}</div>
-            {:else if selectedSnapshot.count != null}
-              <div><strong>Detections:</strong> {selectedSnapshot.count}</div>
-            {/if}
-            {#if modalSnapshots.length > 1}
-              <div style="margin-top: 0.4rem; font-size: 0.75rem; opacity: 0.8;">
-                {selectedSnapshotIndex + 1} / {modalSnapshots.length} | Arrow keys to navigate
-              </div>
-            {/if}
-          </div>
-        </div>
-      </div>
-    {/if}
   </div>
 
   <!-- Main Content Row -->
@@ -1111,4 +1050,66 @@
       {/if}
     </div>
   </div>
+
+  <!-- Fullscreen Snapshot Modal -->
+  {#if selectedSnapshot}
+    <div class="snapshot-modal-overlay" on:click="{closeSnapshotModal}">
+      <div
+        bind:this="{modalContentEl}"
+        class="snapshot-modal-content"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Fullscreen snapshot viewer"
+        on:click|stopPropagation
+      >
+        <button
+          bind:this="{closeButtonEl}"
+          class="snapshot-modal-close"
+          on:click="{closeSnapshotModal}"
+          title="Close (ESC)"
+          aria-label="Close snapshot viewer"
+        >
+          <i class="fas fa-times" aria-hidden="true"></i>
+        </button>
+
+        {#if modalSnapshots.length > 1 && selectedSnapshotIndex > 0}
+          <button
+            class="snapshot-modal-nav prev"
+            on:click="{showPreviousSnapshot}"
+            title="Previous (←)"
+            aria-label="Previous snapshot"
+          >
+            <i class="fas fa-chevron-left" aria-hidden="true"></i>
+          </button>
+        {/if}
+
+        <img src="{selectedSnapshot.path}" alt="Fullscreen snapshot" class="snapshot-modal-image" />
+
+        {#if modalSnapshots.length > 1 && selectedSnapshotIndex < modalSnapshots.length - 1}
+          <button
+            class="snapshot-modal-nav next"
+            on:click="{showNextSnapshot}"
+            title="Next (→)"
+            aria-label="Next snapshot"
+          >
+            <i class="fas fa-chevron-right" aria-hidden="true"></i>
+          </button>
+        {/if}
+
+        <div class="snapshot-modal-info">
+          <div><strong>Detected:</strong> {formatDate(selectedSnapshot.timestamp)}</div>
+          {#if selectedSnapshot.metadata?.detection_count != null}
+            <div><strong>Detections:</strong> {selectedSnapshot.metadata.detection_count}</div>
+          {:else if selectedSnapshot.count != null}
+            <div><strong>Detections:</strong> {selectedSnapshot.count}</div>
+          {/if}
+          {#if modalSnapshots.length > 1}
+            <div style="margin-top: 0.4rem; font-size: 0.75rem; opacity: 0.8;">
+              {selectedSnapshotIndex + 1} / {modalSnapshots.length} | Arrow keys to navigate
+            </div>
+          {/if}
+        </div>
+      </div>
+    </div>
+  {/if}
 </div>

--- a/gui/pages/Monitoring.svelte
+++ b/gui/pages/Monitoring.svelte
@@ -577,14 +577,18 @@
   const loadSnapshots = async () => {
     try {
       const offset = currentPage * snapshotsPerPage;
-      let url = `${nocturnalEyeApi}/snapshots/recent?limit=${snapshotsPerPage}&offset=${offset}`;
+      let url = `${nocturnalEyeApi}/snapshots/recent?limit=${snapshotsPerPage}`;
 
+      // Use range endpoint only if user has explicitly set both dates
       if (fromDate && toDate) {
         const fromDateTime = `${fromDate}T${fromTime}:00`;
         const toDateTime = `${toDate}T${toTime}:59`;
         url = `${nocturnalEyeApi}/snapshots/range?limit=${snapshotsPerPage}&offset=${offset}`;
         url += `&start=${encodeURIComponent(fromDateTime)}`;
         url += `&end=${encodeURIComponent(toDateTime)}`;
+      } else if (offset > 0) {
+        // Add offset for pagination when not using range filter
+        url += `&offset=${offset}`;
       }
 
       const res = await fetch(url);
@@ -715,13 +719,8 @@
   onMount(() => {
     setCustomPageTitle($_('monitoring.title', { default: 'Monitoring' }));
 
-    // Initialize date inputs with today's date
+    // Initialize activity date inputs with today's date
     const today = new Date().toISOString().split('T')[0];
-    toDate = today;
-    fromDate = today;
-    fromTime = '00:00';
-    toTime = '23:59';
-
     activityFromDate = today;
     activityToDate = today;
     activityFromTime = '00:00';


### PR DESCRIPTION
## Summary
Fixes critical issues preventing the monitoring dashboard from displaying recent detections and activity data properly.

## Issues Fixed

### 1. Page Layout Broken by Modal Placement
**Problem**: The fullscreen snapshot modal was incorrectly placed inside the stats row div, which caused the row to close prematurely and prevented the Recent Detections and Hourly Activity sections from rendering.

**Solution**: Moved the modal component to after all content rows close, outside the grid structure. Since modals use fixed positioning, they should not be nested within document flow.

**Files Changed**: `gui/pages/Monitoring.svelte`

### 2. Recent Snapshots Not Loading on Initial Page Load
**Problem**: The page was setting `fromDate` and `toDate` to today's date on mount, forcing the `/snapshots/range` endpoint to be used instead of `/snapshots/recent`. The range endpoint expected specific ISO datetime format and wasn't loading correctly.

**Solution**: 
- Removed automatic date initialization for snapshot filtering on mount
- Changed logic to use `/snapshots/recent` by default without mandatory date filters
- Only switches to `/snapshots/range` when user explicitly sets both from and to dates
- Kept activity histogram date initialization (activity loads today's data by default)

**Files Changed**: `gui/pages/Monitoring.svelte`

## Testing
- ✅ Monitoring page loads without errors
- ✅ Recent Detections section displays snapshot grid
- ✅ Hourly Activity (24h) chart renders properly
- ✅ Fullscreen snapshot modal works for both Recent Detections and Recent Activity sections
- ✅ Snapshot pagination functions correctly
- ✅ Date range filtering for detections works when user manually sets dates

## Commits
- `fcb83d56`: Move snapshot modal outside of stats row to restore page layout
- `f32f9981`: Initialize recent snapshots loading without mandatory date filter