### PR TITLE
[BUG FIX] Fix nocturnal-eye HLS chunk URLs

### DIFF
--- a/terrariumWebserver.py
+++ b/terrariumWebserver.py
@@ -331,11 +331,10 @@ class terrariumWebserver(object):
             with open(stream_file, "r") as f:
                 content = f.read()
 
-            # Convert relative paths to absolute URLs with proper host:port for HLS protocol compliance
-            # Use configured host and port instead of untrusted Host header to prevent injection attacks
-            configured_host = f"{self.engine.settings['host']}:{self.engine.settings['port']}"
+            # Convert relative paths to host-relative URLs so clients use the same origin as the manifest
+            # This avoids breaking playback when the configured host is not reachable by the client.
             content = re.sub(
-                r"^(chunk_\d+\.ts)$", f"http://{configured_host}/nocturnal-eye/chunks/\\1", content, flags=re.MULTILINE
+                r"^(chunk_\d+\.ts)$", "/nocturnal-eye/chunks/\\1", content, flags=re.MULTILINE
             )
 
             return content


### PR DESCRIPTION
## Summary
- rewrite nocturnal-eye HLS manifest chunk paths to be host-relative
- avoid hardcoding configured host/port in stream manifest

## Testing
- not run (stream fix only)